### PR TITLE
Fix: leave only code review mates and mentors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pre-lang @MiaJLee @milooy @evan-moon
+* @pa-rang @MiaJLee @milooy @evan-moon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pre-lang @s-ong-c @MiaJLee @devGW @milooy @evan-moon
+* @pre-lang @MiaJLee @milooy @evan-moon


### PR DESCRIPTION
## 내용
`CODEOWNERS` 파일에 리뷰 메이트와 멘토만 남기도록 수정