### PR TITLE
Dev/ 메인페이지 템플릿 추가 및 적용

### DIFF
--- a/src/components/molecules/GNB.tsx
+++ b/src/components/molecules/GNB.tsx
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+import Logo from 'components/atoms/Logo';
+import SearchInput from './SearchInput';
+import UserProfile from './UserProfile';
+
+const GNB = () => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: row;
+        padding: 10px 20px;
+        background-color: gray;
+      `}
+    >
+      <Logo />
+      <SearchInput />
+      <UserProfile
+        name="Junimo"
+        profileImageUrl="https://cdn6.f-cdn.com/contestentries/1376995/30494909/5b566bc71d308_thumbCard.jpg"
+      />
+    </div>
+  );
+};
+
+export default GNB;

--- a/src/components/molecules/SearchInput.tsx
+++ b/src/components/molecules/SearchInput.tsx
@@ -1,0 +1,30 @@
+import { css } from '@emotion/react';
+
+const SearchInput = () => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        margin-left: 100px;
+      `}
+    >
+      <input
+        css={css`
+          width: 300px;
+        `}
+        placeholder="검색어를 입력해주세요."
+        type="text"
+      />
+      <button
+        type="button"
+        css={css`
+          padding: 0 20px;
+        `}
+      >
+        검색
+      </button>
+    </div>
+  );
+};
+
+export default SearchInput;

--- a/src/components/molecules/SideMenu.tsx
+++ b/src/components/molecules/SideMenu.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { css } from '@emotion/react';
+import { Link } from 'react-router-dom';
+import linkStyle from 'styles/link';
+import { externaURL } from 'utils/url';
+import LinkButton from 'components/atoms/LinkButton';
+
+const sideMenuStyle = css`
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  background-color: lightblue;
+  transition: width ease 0.6s;
+  overflow: hidden;
+
+  &.opened {
+    width: 200px;
+  }
+
+  &.closed {
+    width: 50px;
+  }
+
+  > a {
+    ${linkStyle}
+    background-color: gray;
+    padding: 20px 0;
+    margin-top: 10px;
+    white-space: nowrap;
+    overflow: hidden;
+    :last-of-type {
+      margin-top: auto;
+    }
+  }
+`;
+
+const buttonStyle = css`
+  width: 50px;
+  padding: 10px 0;
+  margin-left: auto;
+`;
+
+const SideMenu = () => {
+  const [isOpened, setIsOpened] = useState(true);
+
+  const handleClickButton = () => {
+    setIsOpened(!isOpened);
+  };
+
+  return (
+    <nav css={sideMenuStyle} className={isOpened ? 'opened' : 'closed'}>
+      <button type="button" css={buttonStyle} onClick={handleClickButton}>
+        {isOpened ? `<<<<` : `>>>>`}
+      </button>
+      <Link to="/archiving-list">{isOpened ? '아카이빙 리스트' : '아'}</Link>
+      <Link to="/careerzip-report">{isOpened ? '커리어집 리포트' : '커'}</Link>
+      <Link to="/project-management">{isOpened ? '프로젝트 관리' : '프'}</Link>
+      <LinkButton href={externaURL.FAQ}>FAQ</LinkButton>
+    </nav>
+  );
+};
+
+export default SideMenu;

--- a/src/components/molecules/UserProfile.tsx
+++ b/src/components/molecules/UserProfile.tsx
@@ -1,0 +1,39 @@
+import { css } from '@emotion/react';
+
+interface TUserProfile {
+  name: string;
+  profileImageUrl: string;
+}
+
+const UserProfile = ({ name, profileImageUrl }: TUserProfile) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-left: auto;
+      `}
+    >
+      <img
+        css={css`
+          width: 45px;
+          height: 45px;
+          border-radius: 100%;
+        `}
+        alt="profile"
+        src={profileImageUrl}
+      />
+      <span
+        css={css`
+          font-weight: bold;
+          margin-left: 10px;
+        `}
+      >
+        {name}
+      </span>
+    </div>
+  );
+};
+
+export default UserProfile;

--- a/src/components/pages/ArchivingList.tsx
+++ b/src/components/pages/ArchivingList.tsx
@@ -1,0 +1,7 @@
+import MainTemplate from 'components/templates/MainTemplate';
+
+const ArchivingList = () => {
+  return <MainTemplate>아카아카</MainTemplate>;
+};
+
+export default ArchivingList;

--- a/src/components/pages/CareerzipReport.tsx
+++ b/src/components/pages/CareerzipReport.tsx
@@ -1,0 +1,7 @@
+import MainTemplate from 'components/templates/MainTemplate';
+
+const CareerzipReport = () => {
+  return <MainTemplate>리포트!</MainTemplate>;
+};
+
+export default CareerzipReport;

--- a/src/components/pages/Main.tsx
+++ b/src/components/pages/Main.tsx
@@ -1,5 +1,7 @@
+import MainTemplate from 'components/templates/MainTemplate';
+
 const Main = () => {
-  return <div>메인임니다</div>;
+  return <MainTemplate>moyaho</MainTemplate>;
 };
 
 export default Main;

--- a/src/components/pages/ProjectManagement.tsx
+++ b/src/components/pages/ProjectManagement.tsx
@@ -1,0 +1,7 @@
+import MainTemplate from 'components/templates/MainTemplate';
+
+const ProjectManagement = () => {
+  return <MainTemplate>프매에오</MainTemplate>;
+};
+
+export default ProjectManagement;

--- a/src/components/templates/MainTemplate.tsx
+++ b/src/components/templates/MainTemplate.tsx
@@ -1,0 +1,36 @@
+import { css } from '@emotion/react';
+import GNB from 'components/molecules/GNB';
+import SideMenu from 'components/molecules/SideMenu';
+
+const MainTemplate = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+      `}
+    >
+      <GNB />
+      <div
+        css={css`
+          display: flex;
+          height: calc(100vh - 65px);
+        `}
+      >
+        <SideMenu />
+        <div
+          css={css`
+            flex: 1;
+            max-width: 100vw;
+            padding: 20px;
+            background-color: greenyellow;
+          `}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MainTemplate;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -2,6 +2,9 @@ import Auth from 'components/pages/Auth';
 import Home from 'components/pages/Home';
 import Login from 'components/pages/Login';
 import Main from 'components/pages/Main';
+import ArchivingList from 'components/pages/ArchivingList';
+import CareerzipReport from 'components/pages/CareerzipReport';
+import ProjectManagement from 'components/pages/ProjectManagement';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 const Router = () => {
@@ -12,6 +15,9 @@ const Router = () => {
         <Route path="/login" component={Login} />
         <Route path="/auth" component={Auth} />
         <Route path="/main" component={Main} />
+        <Route path="/archiving-list" component={ArchivingList} />
+        <Route path="/careerzip-report" component={CareerzipReport} />
+        <Route path="/project-management" component={ProjectManagement} />
       </Switch>
     </BrowserRouter>
   );

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 
 const global = css`
   body {
+    box-sizing: border-box;
     font-family: 'NanumBarunGothic', sans-serif;
   }
 `;


### PR DESCRIPTION
## 내용
- 메인페이지 템플릿을 구성하고 적용하였습니다.
- 사이드바 메뉴에 따라 아카이빙 리스트, 커리어집 리포트, 프로젝트 관리 페이지를 라우터에 추가하였습니다.

사이드바 열었을 때
<img width="1000" alt="Screen Shot 2021-05-29 at 1 43 44 AM" src="https://user-images.githubusercontent.com/53831646/120016278-5eaf5480-c01f-11eb-9fb1-9d75730f242c.png">

사이드바 닫았을 때
<img width="1439" alt="Screen Shot 2021-05-29 at 1 47 59 AM" src="https://user-images.githubusercontent.com/53831646/120016737-eb5a1280-c01f-11eb-9268-91b3b78f48db.png">

