### PR TITLE
Fix: turn off no circular dependency rule for redux slice file 재도전...!

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,8 @@
     {
       "files": ["./src/slices/*.ts"],
       "rules": {
-        "no-param-reassign": 0
+        "no-param-reassign": 0,
+        "import/no-cycle": 0
       }
     }
   ],


### PR DESCRIPTION
## 내용
이전 PR에서 circular dependency를 없애고자 https://github.com/Lubycon/career-zip-frontend/pull/15#discussion_r641936292 에서 useSelector 콜백을 컴포넌트에서 인라인으로 작성해주어 해결해주었는데요, 
이번에는`createAsyncThunk`를 사용 중 `thunkApi.getState()`를 사용하는 과정에서 `createAsyncThunk<IResponse, void, { state: RootState }>`로 RootState를 타입으로 사용해야하는 상황이 발생하였습니다. 

```typescript
export const getArchivingListAsync = createAsyncThunk<IResponse, void, { state: RootState }>(
  'getArchivingListAsync',
  async (args, thunkAPI) => {
    const {
      page: { currentPage },
      direction,
    } = thunkAPI.getState().archivingList;
//...
  }
);
```
공식 docs에도 제대로 안나와있는 것 같고, 구글링해보니 스택오버플로우에서 동일한 상황의 질문을 발견했습니다.
답변으로 런타임에는 영향을 안주고 컴파일시에만 이용되니 괜찮다는 답변이 달려있어서 사용해도 될 것 같아 다시 한 번 도전합니닷!
https://stackoverflow.com/questions/63923025/how-to-fix-circular-dependencies-of-slices-with-the-rootstate