### PR TITLE
메인 페이지 링크 공유하기 버튼에 링크 클립보드 복사 기능 추가

### DIFF
--- a/src/components/molecules/HomeShareSection.tsx
+++ b/src/components/molecules/HomeShareSection.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { Flex, Text } from 'rebass';
-import { BLUE, DARK_GRAY, GRAY } from 'styles/colors';
-import { useToast } from 'context/Toast';
+import { BLUE, GRAY } from 'styles/colors';
 import { getLocalStorageItem, setLocalStorageItem } from 'utils/localstorage';
 import { getShareCount, increaseShareCount } from 'api/common';
+import useCopyLink from 'hooks/useCopyLink';
 
 const Background = styled.div`
   display: flex;
@@ -31,7 +31,7 @@ const ShareButton = styled.button`
 `;
 
 const HomeShareSection = () => {
-  const { showToast } = useToast();
+  const { copyLink } = useCopyLink();
   const [shareCount, setShareCount] = useState(0);
 
   useEffect(() => {
@@ -45,28 +45,11 @@ const HomeShareSection = () => {
   }, []);
 
   const handleClick = async () => {
-    let isCopied = false;
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      showToast({
-        message: (
-          <Text fontWeight="bold" fontSize="20px" color={DARK_GRAY[2]} padding="0 85px">
-            🔗 공유 링크가 복사 되었습니다!
-          </Text>
-        ),
-      });
-      isCopied = true;
-    } catch (err) {
-      <Text fontWeight="bold" fontSize="20px" color={DARK_GRAY[2]} padding="0 85px">
-        문제가 발생하여 링크를 복사하지 못했어요.😥 다시 시도해주세요.
-      </Text>;
-    }
-    if (isCopied) {
-      const hasEverShared = getLocalStorageItem<boolean>('hasEverShared');
-      if (!hasEverShared) {
-        setLocalStorageItem<boolean>('hasEverShared', true);
-        await increaseShareCount();
-      }
+    copyLink();
+    const hasEverShared = getLocalStorageItem<boolean>('hasEverShared');
+    if (!hasEverShared) {
+      setLocalStorageItem<boolean>('hasEverShared', true);
+      await increaseShareCount();
     }
   };
 

--- a/src/components/molecules/SideMenu.tsx
+++ b/src/components/molecules/SideMenu.tsx
@@ -5,6 +5,7 @@ import { BLUE, GRAY } from 'styles/colors';
 import ShortLogo from 'components/atoms/ShortLogo';
 import { Box } from 'rebass';
 import { useHistory } from 'react-router';
+import useCopyLink from 'hooks/useCopyLink';
 
 const StyledSideMenu = styled.nav`
   display: flex;
@@ -84,6 +85,7 @@ const MenuButton = ({ className, isCollapsed = false, emoji, name, onClick }: Me
 
 const SideMenu = () => {
   const history = useHistory();
+  const { copyLink } = useCopyLink();
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const handleIsCollapsed = () => {
@@ -94,7 +96,9 @@ const SideMenu = () => {
     history.push(page);
   };
 
-  const handleClickCopyURL = () => {};
+  const handleClickCopyURL = () => {
+    copyLink();
+  };
 
   return (
     <StyledSideMenu className={isCollapsed ? 'collapsed' : undefined}>

--- a/src/hooks/useCopyLink.tsx
+++ b/src/hooks/useCopyLink.tsx
@@ -1,0 +1,31 @@
+import { useToast } from 'context/Toast';
+import { Text } from 'rebass';
+import { DARK_GRAY } from 'styles/colors';
+
+const useCopyLink = () => {
+  const { showToast } = useToast();
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      showToast({
+        message: (
+          <Text fontWeight="bold" fontSize="20px" color={DARK_GRAY[2]} padding="0 85px">
+            🔗 공유 링크가 복사 되었습니다!
+          </Text>
+        ),
+      });
+      throw new Error();
+    } catch (err) {
+      <Text fontWeight="bold" fontSize="20px" color={DARK_GRAY[2]} padding="0 85px">
+        문제가 발생하여 링크를 복사하지 못했어요.😥 다시 시도해주세요.
+      </Text>;
+    }
+  };
+
+  return {
+    copyLink,
+  };
+};
+
+export default useCopyLink;


### PR DESCRIPTION
## 내용
- 랜딩페이지에도 동일한 기능이 있어 custom hook을 만들었습니다.

## 참고사항
- 랜딩페이지에서 공유 수를 증가시키는 기준을 `clipboard.writeText` API가 잘 동작해서 복사에 **성공**했을 때만 공유 수를 증가시키는 API를 호출하였는데요, API 성공 여부보다는 사용자가 복사를 하려고 클릭했는지가 더 맞는 기준인 것 같아 관련 로직을 제거하였습니다.
  - 기존 코드
  ```typescript
  const handleClick = async () => {
    let isCopied = false;
    try {
      await navigator.clipboard.writeText(window.location.href);
      showToast({
        message: (
          <Text fontWeight="bold" fontSize="20px" color={DARK_GRAY[2]} padding="0 85px">
            🔗 공유 링크가 복사 되었습니다!
          </Text>
        ),
      });
      isCopied = true;
    } catch (err) {
      <Text fontWeight="bold" fontSize="20px" color={DARK_GRAY[2]} padding="0 85px">
        문제가 발생하여 링크를 복사하지 못했어요.😥 다시 시도해주세요.
      </Text>;
    }
    if (isCopied) {
      const hasEverShared = getLocalStorageItem<boolean>('hasEverShared');
      if (!hasEverShared) {
        setLocalStorageItem<boolean>('hasEverShared', true);
        await increaseShareCount();
      }
    }
  };
  ```
  - 변경된 코드
   ```typescript
  const handleClick = async () => {
    copyLink();
    const hasEverShared = getLocalStorageItem<boolean>('hasEverShared');
    if (!hasEverShared) {
      setLocalStorageItem<boolean>('hasEverShared', true);
      await increaseShareCount();
    }
  };
```