### PR TITLE
사이드바 항상 왼쪽 상단에 고정되도록 스타일 수정

### DIFF
--- a/src/components/molecules/SideMenu.tsx
+++ b/src/components/molecules/SideMenu.tsx
@@ -8,6 +8,8 @@ import { useHistory } from 'react-router';
 import useCopyLink from 'hooks/useCopyLink';
 
 const StyledSideMenu = styled.nav`
+  position: sticky;
+  top: 0;
   display: flex;
   flex-direction: column;
   width: 342px;

--- a/src/components/templates/MainTemplate.tsx
+++ b/src/components/templates/MainTemplate.tsx
@@ -6,7 +6,7 @@ const MainTemplate = ({ children }: { children: React.ReactNode }) => {
   return (
     <Flex minHeight="100vh" maxHeight="100vh">
       <SideMenu />
-      <Flex flexDirection="column" flex="1">
+      <Flex flexDirection="column" flex="1" maxHeight="100vh" overflowY="auto">
         <GNB />
         <Box padding="10px 240px 147px 160px">{children}</Box>
       </Flex>


### PR DESCRIPTION
## 내용
- 사이드바는 항상 왼쪽 상단에 고정되고, 오른쪽 화면만 스크롤이 가능하다.

- 참고 이미지
<img width="1439" alt="Screen Shot 2021-06-14 at 1 50 18 AM" src="https://user-images.githubusercontent.com/53831646/121815747-e39e9d00-ccb2-11eb-879d-20051944a04a.png">
