### PR TITLE
Feat: 페이지가 변경되어도 사이드메뉴 collapsed 상태 유지

### DIFF
--- a/src/components/molecules/SideMenu.tsx
+++ b/src/components/molecules/SideMenu.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
 import styled from '@emotion/styled';
-import BetaLogo from 'components/atoms/BetaLogo';
-import { BLUE, GRAY } from 'styles/colors';
-import ShortLogo from 'components/atoms/ShortLogo';
-import { Box } from 'rebass';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
+import { Box } from 'rebass';
+import BetaLogo from 'components/atoms/BetaLogo';
+import ShortLogo from 'components/atoms/ShortLogo';
 import useCopyLink from 'hooks/useCopyLink';
+import { selectIsSideMenuCollapsed, toggleSideMenuCollapsed } from 'slices/common';
+import { BLUE, GRAY } from 'styles/colors';
 
 const StyledSideMenu = styled.nav`
   position: sticky;
@@ -88,10 +89,11 @@ const MenuButton = ({ className, isCollapsed = false, emoji, name, onClick }: Me
 const SideMenu = () => {
   const history = useHistory();
   const { copyLink } = useCopyLink();
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const dispatch = useDispatch();
+  const isCollapsed = useSelector(selectIsSideMenuCollapsed);
 
   const handleIsCollapsed = () => {
-    setIsCollapsed(!isCollapsed);
+    dispatch(toggleSideMenuCollapsed());
   };
 
   const handleClickMenu = (page: string) => () => {

--- a/src/slices/common.ts
+++ b/src/slices/common.ts
@@ -1,0 +1,27 @@
+import { createAction, createSlice } from '@reduxjs/toolkit';
+import { RootState } from 'slices';
+
+interface TInitialState {
+  isSideMenuCollapsed: boolean;
+}
+
+const initialState: TInitialState = {
+  isSideMenuCollapsed: false,
+};
+
+export const toggleSideMenuCollapsed = createAction('setAccountInfo');
+
+const commonSlice = createSlice({
+  name: 'common',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(toggleSideMenuCollapsed, (state) => {
+      state.isSideMenuCollapsed = !state.isSideMenuCollapsed;
+    });
+  },
+});
+
+export const selectIsSideMenuCollapsed = (state: RootState) => state.common.isSideMenuCollapsed;
+
+export default commonSlice.reducer;

--- a/src/slices/index.ts
+++ b/src/slices/index.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import account from './account';
+import common from './common';
 import archivingList from './archiving-list';
 
 const store = configureStore({
   reducer: {
     account,
+    common,
     archivingList,
   },
 });


### PR DESCRIPTION
## 내용
- redux 상태에 저장하여 페이지가 변경되어도 상태를 유지하도록 함